### PR TITLE
aprobación metodo CORS para poder conectar el frontend y traer el endpoint GET

### DIFF
--- a/restaurantes_app/restaurantes_app/settings.py
+++ b/restaurantes_app/restaurantes_app/settings.py
@@ -129,3 +129,5 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+CORS_ALLOWED_ORIGINS = ["http://localhost:3000/"]


### PR DESCRIPTION
Implemento configuración CORS para autorizar solicitudes GET originadas desde el frontend y dirigidas al endpoint con el fin de establecer la comunicación entre ambas partes.